### PR TITLE
Clarify that this isn't VPC-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [AWS Lambda](https://aws.amazon.com/documentation/lambda/) function to send [CloudWatch](https://www.amazonaws.cn/en/cloudwatch/) logs to the [Logsene logging SaaS](https://sematext.com/logsene). As new log events are being stored in CloudWatch, this function would forward the events to your Logsene application.
 
 ## How To (VPC example)
-This tutorial shows how to send [AWS VPC](https://aws.amazon.com/vpc/) logs to a Logsene application. VPC logs are one type of CloudWatch logs, for which this function has built-in parsing. If you're using a type of CloudWatch logs that isn't support it, feel free to edit **pattern.yml** or to open an issue.
+This tutorial shows how to send [AWS VPC](https://aws.amazon.com/vpc/) logs to a Logsene application. VPC logs are one type of CloudWatch logs, for which this function has built-in parsing. If you're using a type of CloudWatch logs that isn't supported yet, feel free to edit **pattern.yml** or to open an issue.
 
 The main steps are:
  0. Create a Flow Log for your VPC, if there isn't one already. **If you're looking to ship other CloudWatch logs, just skip this step and go through the rest**.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![cloudwatch->Logsene](https://sematext.com/wp-content/uploads/2016/03/aws-cloudwatch.png)
-# logsene-aws-lambda-cloudwatch
-[AWS Lambda](https://aws.amazon.com/documentation/lambda/) function to send [CloudWatch](https://www.amazonaws.cn/en/cloudwatch/) logs, and has built-in parsing for [AWS VPC](https://aws.amazon.com/vpc/) logs. As new log events are being stored in CloudWatch, this function would forward the events to your Logsene application.
+# CloudWatch to Logsene AWS Lambda function
+[AWS Lambda](https://aws.amazon.com/documentation/lambda/) function to send [CloudWatch](https://www.amazonaws.cn/en/cloudwatch/) logs to the [Logsene logging SaaS](https://sematext.com/logsene). As new log events are being stored in CloudWatch, this function would forward the events to your Logsene application.
 
-## How To
-This tutorial shows how to send AWS VPC logs (one type of CloudWatch logs) to a Logsene application.
+## How To (VPC example)
+This tutorial shows how to send [AWS VPC](https://aws.amazon.com/vpc/) logs to a Logsene application. VPC logs are one type of CloudWatch logs, for which this function has built-in parsing. If you're using a type of CloudWatch logs that isn't support it, feel free to edit **pattern.yml** or to open an issue.
 
 The main steps are:
- 0. Create a Flow Log for your VPC, if there isn't one already
+ 0. Create a Flow Log for your VPC, if there isn't one already. **If you're looking to ship other CloudWatch logs, just skip this step and go through the rest**.
  1. Create a new Lambda Function
  2. Clone this repository and fill in your Logsene Application Token, create a ZIP file with the contents of the cloned repository, and configure the new Lambda function to use the created ZIP file as code
  3. Decide on the maximum memory to allocate for this function and the timeout for its execution


### PR DESCRIPTION
This function can ship any kind of CloudWatch logs, it just happens to parse the VPC ones by default (we hope other types will follow). The README makes it now more clear.